### PR TITLE
Using tsloader instead of babel

### DIFF
--- a/test/end-to-end/webpack.config.js
+++ b/test/end-to-end/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = async (env, options) => {
     },
     output: {
       path: path.resolve(__dirname, "testBuild"),
-      devtoolModuleFilenameTemplate: "webpack:///[resource-path]?[loaders]",
       clean: true,
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = async (env, options) => {
       commands: "./src/commands/commands.js",
     },
     output: {
-      devtoolModuleFilenameTemplate: "webpack:///[resource-path]?[loaders]",
       clean: true,
     },
     resolve: {
@@ -42,13 +41,6 @@ module.exports = async (env, options) => {
             options: {
               presets: ["@babel/preset-env"],
             },
-          },
-        },
-        {
-          test: /functions.js$/,
-          exclude: /node_modules/,
-          use: {
-            loader: "ts-loader",
           },
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,10 +38,7 @@ module.exports = async (env, options) => {
           test: /\.js$/,
           exclude: /node_modules/,
           use: {
-            loader: "babel-loader", 
-            options: {
-              presets: ["@babel/preset-env"],
-            },
+            loader: "ts-loader"
           },
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,17 @@ module.exports = async (env, options) => {
           test: /\.js$/,
           exclude: /node_modules/,
           use: {
-            loader: "ts-loader"
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env"],
+            },
+          },
+        },
+        {
+          test: /functions.js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "ts-loader",
           },
         },
         {


### PR DESCRIPTION
The problem is that breakpoints are not getting hit on Excel Custom Functions JavaScript.
That's because the built file `functions.js.map` had:
`sources: "webpack:///./src/functions/functions.js"` and it should actually be:
`sources:"webpack:///./src/functions/functions.js?./node_modules/custom-functions-metadata-plugin/lib/loader.js?{\"input\":\".\\src\\functions\\functions.js\"}"` which makes the custom-functions-metadata-plugin get called correctly.

I'm not sure why the normal babel-loader does that different than the `ts-loader` but my guess is that the plugin was mostly tested for TypeScript and doesn't work for JavaScript loaders normally.

---

**Change Description**:

    Describe what the PR is about. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
No

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.
No

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

Ran `npm run start` and run the debugger target `Excel Desktop (Custom Functions)` and verified that the breakpoints do get hit.
