### PR TITLE
Fix manifest for shared runtime

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -39,7 +39,7 @@
               <SourceLocation resid="Functions.Script.Url" />
             </Script>
             <Page>
-              <SourceLocation resid="Functions.Page.Url"/>
+              <SourceLocation resid="Taskpane.Url"/>
             </Page>
             <Metadata>
               <SourceLocation resid="Functions.Metadata.Url" />
@@ -94,7 +94,6 @@
       <bt:Urls>
         <bt:Url id="Functions.Script.Url" DefaultValue="https://localhost:3000/public/functions.js" />
         <bt:Url id="Functions.Metadata.Url" DefaultValue="https://localhost:3000/public/functions.json" />
-        <bt:Url id="Functions.Page.Url" DefaultValue="https://localhost:3000/taskpane.html"/>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812" />
         <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3000/taskpane.html"/>
       </bt:Urls>


### PR DESCRIPTION
**Change Description**:

    Shared runtime currently not working because all resid entries must match. See https://github.com/OfficeDev/Excel-Custom-Functions/issues/351 for more information.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
 No.


2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    Yes, just minor change in manifest.xml to support shared runtime correctly.


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
