### PR TITLE
[Shared runtime] Use associate instead of global

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 Custom functions enable you to add new functions to Excel by defining those functions in JavaScript as part of an add-in. Users within Excel can access custom functions just as they would any native function in Excel, such as `SUM()`.  
 
-This repository contains the source code used by the [Yo Office generator](https://github.com/OfficeDev/generator-office) when you create a new custom functions project. You can also use this repository as a sample to base your own custom functions project from if you choose not to use the generator. For more detailed information about custom functions in Excel, see the [Custom functions overview](https://docs.microsoft.com/office/dev/add-ins/excel/custom-functions-overview) article in the Office Add-ins documentation or see the [additional resources](#additional-resources) section of this repository.
+This repository contains the source code used by the [Yo Office generator](https://github.com/OfficeDev/generator-office) when you create a new custom functions project. You can also use this repository as a sample to base your own custom functions project from if you choose not to use the generator. For more detailed information about custom functions in Excel, see the [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview) article in the Office Add-ins documentation or see the [additional resources](#additional-resources) section of this repository.
 
 ## Debugging custom functions
 
-This template supports debugging custom functions from [Visual Studio Code](https://code.visualstudio.com/). For more information see [Custom functions debugging](https://aka.ms/custom-functions-debug). For general information on debugging task panes and other Office Add-in parts, see [Test and debug Office Add-ins](https://docs.microsoft.com/office/dev/add-ins/testing/test-debug-office-add-ins).
+This template supports debugging custom functions from [Visual Studio Code](https://code.visualstudio.com/). For more information see [Custom functions debugging](https://aka.ms/custom-functions-debug). For general information on debugging task panes and other Office Add-in parts, see [Test and debug Office Add-ins](https://learn.microsoft.com/office/dev/add-ins/testing/test-debug-office-add-ins).
 
 ## Questions and comments
 
 We'd love to get your feedback about this sample. You can send your feedback to us in the *Issues* section of this repository.
 
-Questions about Office Add-ins development in general should be posted to [Microsoft Q&A](https://docs.microsoft.com/answers/questions/185087/questions-about-office-add-ins.html). If your question is about the Office JavaScript APIs, make sure it's tagged with [office-js-dev].
+Questions about Office Add-ins development in general should be posted to [Microsoft Q&A](https://learn.microsoft.com/answers/questions/185087/questions-about-office-add-ins.html). If your question is about the Office JavaScript APIs, make sure it's tagged with [office-js-dev].
 
 ## Join the Microsoft 365 Developer Program
+
 Get a free sandbox, tools, and other resources you need to build solutions for the Microsoft 365 platform.
+
 - [Free developer sandbox](https://developer.microsoft.com/microsoft-365/dev-program#Subscription) Get a free, renewable 90-day Microsoft 365 E5 developer subscription.
 - [Sample data packs](https://developer.microsoft.com/microsoft-365/dev-program#Sample) Automatically configure your sandbox by installing user data and content to help you build your solutions.
 - [Access to experts](https://developer.microsoft.com/microsoft-365/dev-program#Experts) Access community events to learn from Microsoft 365 experts.
@@ -23,11 +25,11 @@ Get a free sandbox, tools, and other resources you need to build solutions for t
 
 ## Additional resources
 
-* [Custom functions overview](https://docs.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
-* [Custom functions best practices](https://docs.microsoft.com/office/dev/add-ins/excel/custom-functions-best-practices)
-* [Custom functions runtime](https://docs.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
-* [Office Add-ins documentation](https://docs.microsoft.com/office/dev/add-ins/overview/office-add-ins)
-* More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
+- [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
+- [Custom functions best practices](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-best-practices)
+- [Custom functions runtime](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
+- [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
+- More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,8 @@
         "webpack-dev-server": "4.13.1"
       },
       "engines": {
-        "node": ">=16 <19",
-        "npm": ">=7 <10"
+        "node": ">=16 <21",
+        "npm": ">=7 <11"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -3,10 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-/* global global, Office, self, window */
+/* global Office */
 
 Office.onReady(() => {
-  // If needed, Office.js is ready to be called
+  // If needed, Office.js is ready to be called.
 });
 
 /**
@@ -21,24 +21,12 @@ function action(event) {
     persistent: true,
   };
 
-  // Show a notification message
+  // Show a notification message.
   Office.context.mailbox.item.notificationMessages.replaceAsync("action", message);
 
-  // Be sure to indicate when the add-in command function is complete
+  // Be sure to indicate when the add-in command function is complete.
   event.completed();
 }
 
-function getGlobal() {
-  return typeof self !== "undefined"
-    ? self
-    : typeof window !== "undefined"
-    ? window
-    : typeof global !== "undefined"
-    ? global
-    : undefined;
-}
-
-const g = getGlobal();
-
-// the add-in command functions need to be available in global scope
-g.action = action;
+// Register the function with Office.
+Office.actions.associate("action", action);


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    Describe what the PR is about. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start') No
    If Yes, briefly describe what is impacted.


2. **Do these changes impact *VS Code debugging* options (launch.json)?** No
    If Yes, briefly describe what is impacted.


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents) Yes
    If Yes, briefly describe what is impacted.
    Use Office.actions.associate instead of getGlobal


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins) No
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
