### PR TITLE
Fix convertToSingleHost to use execFile

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -305,8 +305,9 @@ if (projectName) {
   }
 
   // Modify the manifest to include the name and id of the project
-  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
-  childProcess.exec(cmdLine, (error, stdout) => {
+  const manifestCli = require.resolve("office-addin-manifest/cli.js");
+  const args = [manifestCli, "modify", manifestPath, "-g", appId, "-d", projectName];
+  childProcess.execFile(process.execPath, args, { shell: false }, (error, stdout) => {
     if (error) {
       console.error(`Error updating the manifest: ${error}`);
       process.exitCode = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "11.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
       "integrity": "sha1-zfPgre0hSSNkpw4ZO0W3z0F38DE=",
       "dev": true,
       "license": "MIT",
@@ -76,7 +76,7 @@
     },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
       "integrity": "sha1-n6CAF/tZ2AU4gS8D/HysWZLKqhc=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +87,7 @@
     },
     "node_modules/@apidevtools/swagger-methods": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
       "integrity": "sha1-t4mjYuBVsDQNBHEur+cCfdwawmc=",
       "dev": true,
       "license": "MIT",
@@ -95,7 +95,7 @@
     },
     "node_modules/@apidevtools/swagger-parser": {
       "version": "10.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
       "integrity": "sha1-4pvxfPlLSHo0DgZ4Tp++IMtnHEU=",
       "dev": true,
       "license": "MIT",
@@ -115,7 +115,7 @@
     },
     "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -133,7 +133,7 @@
     },
     "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha1-O2R2GyaLoLnmaPC0G6U/zgrXf8g=",
       "dev": true,
       "license": "MIT",
@@ -149,7 +149,7 @@
     },
     "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT",
@@ -157,7 +157,7 @@
     },
     "node_modules/@azure/abort-controller": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
       "integrity": "sha1-k+DoKwGGLn6jtbaZWHGdPz/SyKw=",
       "dev": true,
       "license": "MIT",
@@ -171,7 +171,7 @@
     },
     "node_modules/@azure/arm-appservice": {
       "version": "13.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/arm-appservice/-/arm-appservice-13.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/arm-appservice/-/arm-appservice-13.0.3.tgz",
       "integrity": "sha1-zXMoYaBp3ch/9X2jFrKuxllsRr0=",
       "dev": true,
       "license": "MIT",
@@ -191,7 +191,7 @@
     },
     "node_modules/@azure/arm-appservice/node_modules/@azure/abort-controller": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
       "dev": true,
       "license": "MIT",
@@ -205,7 +205,7 @@
     },
     "node_modules/@azure/arm-resources": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
       "integrity": "sha1-voAx+uYTIHNU6YQtaGmPig3H4lA=",
       "dev": true,
       "license": "MIT",
@@ -225,7 +225,7 @@
     },
     "node_modules/@azure/arm-resources/node_modules/@azure/abort-controller": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
       "dev": true,
       "license": "MIT",
@@ -239,7 +239,7 @@
     },
     "node_modules/@azure/arm-storage": {
       "version": "17.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
       "integrity": "sha1-VujwngEau/5b5ffq5HEEdPzaoJY=",
       "dev": true,
       "license": "MIT",
@@ -259,7 +259,7 @@
     },
     "node_modules/@azure/arm-storage/node_modules/@azure/abort-controller": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
       "dev": true,
       "license": "MIT",
@@ -273,7 +273,7 @@
     },
     "node_modules/@azure/arm-subscriptions": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/arm-subscriptions/-/arm-subscriptions-5.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/arm-subscriptions/-/arm-subscriptions-5.1.1.tgz",
       "integrity": "sha1-SCa93tueydSDdfut51kzeMx/gWE=",
       "dev": true,
       "license": "MIT",
@@ -293,7 +293,7 @@
     },
     "node_modules/@azure/core-auth": {
       "version": "1.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-auth/-/core-auth-1.11.0.tgz",
       "integrity": "sha1-Ha7/32LRqHHSK4ZfnzFkpj6h9XU=",
       "dev": true,
       "license": "MIT",
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-client/-/core-client-1.11.0.tgz",
-      "integrity": "sha1-5z0JrHl33l17QVaWt+1F0/3rZ7A=",
+      "version": "1.11.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-client/-/core-client-1.11.1.tgz",
+      "integrity": "sha1-2ZCHiohXdQerETGTW0c0sppjfVg=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -329,7 +329,7 @@
     },
     "node_modules/@azure/core-http-compat": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-http-compat/-/core-http-compat-2.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-http-compat/-/core-http-compat-2.5.0.tgz",
       "integrity": "sha1-14BmGln4pDL+yyt8b6LVgi3KHeo=",
       "dev": true,
       "license": "MIT",
@@ -347,7 +347,7 @@
     },
     "node_modules/@azure/core-lro": {
       "version": "2.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-lro/-/core-lro-2.7.2.tgz",
       "integrity": "sha1-eHEFAnog5Fx3ZRqYsBpNOwG3Wgg=",
       "dev": true,
       "license": "MIT",
@@ -364,7 +364,7 @@
     },
     "node_modules/@azure/core-paging": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-paging/-/core-paging-1.7.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-paging/-/core-paging-1.7.0.tgz",
       "integrity": "sha1-WVl6L1Q4ujxsh4n8hw9p4OeFMag=",
       "dev": true,
       "license": "MIT",
@@ -376,9 +376,20 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@azure/core-process": {
+      "version": "1.0.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-process/-/core-process-1.0.0.tgz",
+      "integrity": "sha1-w68cFyI9ZTjhs2ln3clM2uUyy4M=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.25.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
       "integrity": "sha1-kupJEu27H3OV9IKaMAYxF0qoLwg=",
       "dev": true,
       "license": "MIT",
@@ -398,7 +409,7 @@
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
       "integrity": "sha1-1lenAOJNJW0ZXmKKeV22qMxHXqs=",
       "dev": true,
       "license": "MIT",
@@ -412,7 +423,7 @@
     },
     "node_modules/@azure/core-util": {
       "version": "1.14.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-util/-/core-util-1.14.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-util/-/core-util-1.14.0.tgz",
       "integrity": "sha1-fOn+V5WPEy3UIlc4VuWkXHIyuwQ=",
       "dev": true,
       "license": "MIT",
@@ -428,7 +439,7 @@
     },
     "node_modules/@azure/core-xml": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-xml/-/core-xml-1.6.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/core-xml/-/core-xml-1.6.0.tgz",
       "integrity": "sha1-EI8JIOG834owuffoh5ibOhIIK9k=",
       "dev": true,
       "license": "MIT",
@@ -442,9 +453,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
-      "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
+      "version": "4.13.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/identity/-/identity-4.13.2.tgz",
+      "integrity": "sha1-zq1+af9YbcKL67rqIgG2u2lguE8=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -452,22 +463,23 @@
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.9.0",
         "@azure/core-client": "^1.9.2",
+        "@azure/core-process": "^1.0.0",
         "@azure/core-rest-pipeline": "^1.17.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
         "@azure/msal-browser": "^5.5.0",
-        "@azure/msal-node": "^5.1.0",
+        "@azure/msal-node": "^5.1.5",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "dev": true,
       "license": "MIT",
@@ -481,7 +493,7 @@
     },
     "node_modules/@azure/identity/node_modules/open": {
       "version": "10.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/open/-/open-10.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/open/-/open-10.2.0.tgz",
       "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
       "dev": true,
       "license": "MIT",
@@ -501,7 +513,7 @@
     },
     "node_modules/@azure/logger": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/logger/-/logger-1.4.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/logger/-/logger-1.4.0.tgz",
       "integrity": "sha1-PVpif+WaJ27OdIenndkq1cUIwzk=",
       "dev": true,
       "license": "MIT",
@@ -515,23 +527,23 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
-      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
+      "version": "5.21.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-browser/-/msal-browser-5.21.0.tgz",
+      "integrity": "sha1-2xXEl12SHz/scS4VnJaWwHUdhTw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2"
+        "@azure/msal-common": "16.14.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
+      "version": "16.14.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.14.0.tgz",
+      "integrity": "sha1-zd2zjYMr4OG+YifqZNTrEZmXInw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -540,14 +552,14 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-node/-/msal-node-5.4.1.tgz",
-      "integrity": "sha1-PWogGDnMfAogM9lqLW7pEXYcrMs=",
+      "version": "5.6.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-5.6.0.tgz",
+      "integrity": "sha1-jL/v8CG20vPQZKOvuCJirZhehDQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2",
+        "@azure/msal-common": "16.13.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -591,9 +603,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.13.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.13.0.tgz",
+      "integrity": "sha1-YuQkxrIeFD6O9DdKZNv4dy3+Ggc=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/storage-blob": {
       "version": "12.33.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
       "integrity": "sha1-EK1FhvSSJzG4t5zIa+ytp1Z6H6s=",
       "dev": true,
       "license": "MIT",
@@ -619,16 +642,16 @@
       }
     },
     "node_modules/@azure/storage-common": {
-      "version": "12.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/storage-common/-/storage-common-12.4.1.tgz",
-      "integrity": "sha1-eMI6si3QTOJ7E9/omRtFtv3ts0U=",
+      "version": "12.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-common/-/storage-common-12.5.0.tgz",
+      "integrity": "sha1-nbHWmPJu9LVqVKYABGp2XqG7oxY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-http-compat": "^2.4.0",
         "@azure/core-rest-pipeline": "^1.24.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
@@ -637,7 +660,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2210,7 +2233,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha1-EgIkUMRaTabY2Ch7GKT/Ldsj92g=",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2491,7 @@
     },
     "node_modules/@exodus/schemasafe": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha1-cxZWq+Iejnaaf3Ck2DPmMS/lm38=",
       "dev": true,
       "license": "MIT",
@@ -2476,7 +2499,7 @@
     },
     "node_modules/@feathersjs/hooks": {
       "version": "0.6.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@feathersjs/hooks/-/hooks-0.6.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@feathersjs/hooks/-/hooks-0.6.5.tgz",
       "integrity": "sha1-XRD1PXSlhyiNNWUmsBoOO5rteIM=",
       "dev": true,
       "license": "MIT",
@@ -2486,52 +2509,55 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha1-IqGxGc01+72eVOFupHlYlHLxnbA=",
+      "version": "2.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha1-nPqGSensvNSO31BbEDACQC6lHnA=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha1-qCcsoDsqz0kmcCIrIyC2xCG/3mA=",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha1-j4AMzME/T4zTEW4tnAqUk52j4+0=",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha1-8qCfYgEjkLK/8/xvskjd7IwJoJA=",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -4166,7 +4192,7 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha1-LVmuOrSzj7QnC/oj0w+OLobH/jI=",
       "dev": true,
       "license": "ISC",
@@ -4227,7 +4253,7 @@
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha1-nfA7vXxpalxYiFw0qgbaQchUN5Y=",
       "dev": true,
       "license": "MIT",
@@ -4671,9 +4697,9 @@
       "dev": true
     },
     "node_modules/@microsoft/app-manifest": {
-      "version": "1.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/app-manifest/-/app-manifest-1.0.7.tgz",
-      "integrity": "sha1-0+sp26sVBEHWFTXcL8xieyXnsas=",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/app-manifest/-/app-manifest-1.1.1.tgz",
+      "integrity": "sha1-w2NwblkrkH7nynrOKHIv/zftuBU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4746,7 +4772,7 @@
     },
     "node_modules/@microsoft/dev-tunnels-contracts": {
       "version": "1.1.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/dev-tunnels-contracts/-/dev-tunnels-contracts-1.1.9.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/dev-tunnels-contracts/-/dev-tunnels-contracts-1.1.9.tgz",
       "integrity": "sha1-ttCfjV9gOtsaS9Qhsp654axd9Bg=",
       "dev": true,
       "license": "MIT",
@@ -4759,7 +4785,7 @@
     },
     "node_modules/@microsoft/dev-tunnels-management": {
       "version": "1.1.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/dev-tunnels-management/-/dev-tunnels-management-1.1.9.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/dev-tunnels-management/-/dev-tunnels-management-1.1.9.tgz",
       "integrity": "sha1-f/qB4Ski9sC+ow20B7TtOqzma0Q=",
       "dev": true,
       "license": "MIT",
@@ -4774,7 +4800,7 @@
     },
     "node_modules/@microsoft/kiota": {
       "version": "1.31.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/kiota/-/kiota-1.31.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/kiota/-/kiota-1.31.1.tgz",
       "integrity": "sha1-gdoUDd68bcPdp9LSsdkU0KpCswU=",
       "dev": true,
       "license": "MIT",
@@ -4788,7 +4814,7 @@
     },
     "node_modules/@microsoft/kiota/node_modules/adm-zip": {
       "version": "0.5.18",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/adm-zip/-/adm-zip-0.5.18.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.5.18.tgz",
       "integrity": "sha1-KDoF8r8eP9MV8PMc3im3puPBYZ0=",
       "dev": true,
       "license": "MIT",
@@ -4799,7 +4825,7 @@
     },
     "node_modules/@microsoft/kiota/node_modules/uuid": {
       "version": "13.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-13.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-13.0.2.tgz",
       "integrity": "sha1-QbycB7EvZlCJwgX2UHl2rb34T/g=",
       "dev": true,
       "funding": [
@@ -4814,7 +4840,7 @@
     },
     "node_modules/@microsoft/kiota/node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
       "integrity": "sha1-oyLMDx2X95T/2cTNKomKC94JfzQ=",
       "dev": true,
       "license": "MIT",
@@ -4824,17 +4850,17 @@
       }
     },
     "node_modules/@microsoft/m365-spec-parser": {
-      "version": "0.2.14",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.2.14.tgz",
-      "integrity": "sha1-WA4PLBcQaQefiltl8RJOznDIYq8=",
+      "version": "0.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.3.1.tgz",
+      "integrity": "sha1-0P343A9nGfn1q19CwwxcRw1iyIw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "fs-extra": "^11.2.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "openapi-types": "^7.2.3",
         "swagger2openapi": "^7.0.8"
       },
@@ -4843,9 +4869,9 @@
       }
     },
     "node_modules/@microsoft/m365-spec-parser/node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha1-98uA6d9VDNHbb1N/pc3VaNPnDRA=",
+      "version": "11.4.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha1-+I7W0YCsnhS2GwjmeUaPCxtrRzA=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4859,9 +4885,9 @@
       }
     },
     "node_modules/@microsoft/m365agentstoolkit-cli": {
-      "version": "1.1.12",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.12.tgz",
-      "integrity": "sha1-xhlCQrUHxwUlKws6KNQo+G2BcuQ=",
+      "version": "1.1.15",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.15.tgz",
+      "integrity": "sha1-UChX+eFfkVOLomi7ctU8Dui9PQk=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4870,13 +4896,13 @@
         "@azure/arm-subscriptions": "^5.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/identity": "^4.13.1",
-        "@azure/msal-node": "^5.2.2",
+        "@azure/msal-node": "^5.4.0",
         "@azure/msal-node-extensions": "^1.5.25",
         "@inquirer/core": "^5.1.2",
         "@inquirer/prompts": "^7.10.1",
         "@inquirer/type": "^1.1.5",
-        "@microsoft/teamsfx-api": "0.23.15",
-        "@microsoft/teamsfx-core": "3.0.14",
+        "@microsoft/teamsfx-api": "0.24.1",
+        "@microsoft/teamsfx-core": "3.1.2",
         "ansi-escapes": "^4.3.2",
         "applicationinsights": "^1.8.10",
         "async-mutex": "^0.3.1",
@@ -4891,6 +4917,7 @@
         "node-machine-id": "^1.1.12",
         "open": "^8.2.1",
         "semver": "^7.5.4",
+        "tas-client": "^0.1.73",
         "tree-kill": "^1.2.2",
         "underscore": "^1.13.8"
       },
@@ -4922,7 +4949,7 @@
     },
     "node_modules/@microsoft/teams-manifest": {
       "version": "0.1.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/teams-manifest/-/teams-manifest-0.1.9.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teams-manifest/-/teams-manifest-0.1.9.tgz",
       "integrity": "sha1-UWy/3EZwrSTd22+TVcVRaAIVTqM=",
       "dev": true,
       "license": "MIT",
@@ -4957,7 +4984,7 @@
     },
     "node_modules/@microsoft/teams-manifest/node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha1-O2R2GyaLoLnmaPC0G6U/zgrXf8g=",
       "dev": true,
       "license": "MIT",
@@ -4973,22 +5000,22 @@
     },
     "node_modules/@microsoft/teams-manifest/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@microsoft/teamsfx-api": {
-      "version": "0.23.15",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.23.15.tgz",
-      "integrity": "sha1-u5WtgDi8RGkW0IHCmkLR/k3ZoHM=",
+      "version": "0.24.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.24.1.tgz",
+      "integrity": "sha1-PeQtzsax8sgK9E4RsaaZH4XDOLY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/core-auth": "^1.4.0",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "chai": "^4.3.4",
         "jsonschema": "^1.4.0",
         "neverthrow": "^3.2.0",
@@ -4996,9 +5023,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core": {
-      "version": "3.0.14",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.0.14.tgz",
-      "integrity": "sha1-9ai2++DkttDrWfeTBY1/OwuTjOQ=",
+      "version": "3.1.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.1.2.tgz",
+      "integrity": "sha1-ClJwPJDf8K5+i6PyBlYM9XdbrKQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5011,16 +5038,15 @@
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.22.1",
         "@azure/identity": "^4.1.0",
-        "@azure/msal-node": "^2.6.6",
         "@azure/storage-blob": "^12.25.0",
         "@feathersjs/hooks": "^0.6.5",
         "@microsoft/dev-tunnels-contracts": "1.1.9",
         "@microsoft/dev-tunnels-management": "1.1.9",
         "@microsoft/kiota": "1.31.1",
-        "@microsoft/m365-spec-parser": "^0.2.14",
-        "@microsoft/teamsfx-api": "0.23.15",
+        "@microsoft/m365-spec-parser": "^0.3.1",
+        "@microsoft/teamsfx-api": "0.24.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "ajv": "^8.18.0",
         "axios": "^1.8.3",
         "axios-retry": "^3.3.1",
@@ -5033,10 +5059,11 @@
         "fs-extra": "^9.1.0",
         "glob": "^13.0.0",
         "handlebars": "^4.7.7",
+        "https-proxy-agent": "^7.0.6",
         "iconv-lite": "^0.6.3",
         "ignore": "^5.1.8",
         "js-base64": "^3.6.0",
-        "js-yaml": "^4.0.0",
+        "js-yaml": "^4.3.0",
         "jsonschema": "^1.4.0",
         "klaw": "^3.0.0",
         "linkedom": "^0.18.9",
@@ -5057,43 +5084,28 @@
         "strip-bom": "^4.0.0",
         "swagger2openapi": "^7.0.8",
         "tar": "^7.4.3",
+        "tmp": "^0.2.5",
         "typedi": "^0.10.0",
-        "uuid": "^8.3.2",
+        "uuid": "^11.1.1",
         "validator": "^13.7.0",
         "xml2js": "^0.5.0",
-        "yaml": "^2.2.2"
+        "yaml": "^2.4.2"
       }
     },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+    "node_modules/@microsoft/teamsfx-core/node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-node": {
-      "version": "2.16.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/msal-common": "14.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14.0"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -5111,7 +5123,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "license": "MIT",
@@ -5125,7 +5137,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -5135,9 +5147,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5150,7 +5162,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "license": "MIT",
@@ -5166,7 +5178,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "license": "MIT",
@@ -5177,7 +5189,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "license": "MIT",
@@ -5185,7 +5197,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/commander": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-6.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/commander/-/commander-6.2.1.tgz",
       "integrity": "sha1-B5LraC37wyWZm7K4T93duhEKxzw=",
       "dev": true,
       "license": "MIT",
@@ -5196,7 +5208,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "license": "MIT",
@@ -5207,7 +5219,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-13.0.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/glob/-/glob-13.0.6.tgz",
       "integrity": "sha1-B4ZmVmpCUUfMrPvS4zLetmor5x0=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5226,7 +5238,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "license": "MIT",
@@ -5237,7 +5249,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT",
@@ -5245,7 +5257,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "license": "MIT",
@@ -5255,14 +5267,14 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
+      "version": "10.2.6",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5273,7 +5285,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch/-/node-fetch-3.3.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha1-0eiJus33M7T/OyskPrehKGagt4s=",
       "dev": true,
       "license": "MIT",
@@ -5293,7 +5305,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest": {
       "version": "1.13.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/office-addin-manifest/-/office-addin-manifest-1.13.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-manifest/-/office-addin-manifest-1.13.6.tgz",
       "integrity": "sha1-GAxGKA41dCwtOYUK89WEApqGkaQ=",
       "dev": true,
       "license": "MIT",
@@ -5314,9 +5326,20 @@
         "office-addin-manifest": "cli.js"
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/adm-zip": {
+      "version": "0.5.12",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha1-h3hjKOkdVLNzWNilD5VMTNc7pgs=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "license": "MIT",
@@ -5332,7 +5355,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
       "dev": true,
       "license": "MIT",
@@ -5352,9 +5375,20 @@
         }
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data": {
       "version": "1.6.14",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/office-addin-usage-data/-/office-addin-usage-data-1.6.14.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-usage-data/-/office-addin-usage-data-1.6.14.tgz",
       "integrity": "sha1-OJkGyjsmLtEbxj2fIM691OpPef8=",
       "dev": true,
       "license": "MIT",
@@ -5369,9 +5403,20 @@
         "office-addin-usage-data": "cli.js"
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-2.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha1-a+DQ7gKhDZ4N56mLrmXhgskGH4U=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5389,7 +5434,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -5403,7 +5448,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "dev": true,
       "license": "MIT",
@@ -5414,7 +5459,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "license": "MIT",
@@ -5428,7 +5473,7 @@
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true,
       "license": "MIT",
@@ -5438,14 +5483,14 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha1-eXhti1JeJp3oUKyCsfH3V/ORX0Q=",
+      "version": "1.30.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha1-36ikg0fsLSwNR5F9fcV/dU439f8=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -5481,7 +5526,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
       "dev": true,
       "license": "MIT",
@@ -5496,7 +5541,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -5514,7 +5559,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
       "dev": true,
       "license": "MIT",
@@ -5539,9 +5584,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+      "version": "2.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha1-2TicQ8Coz2o1XbRk0h4HCSpASTo=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5555,7 +5600,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
       "dev": true,
       "license": "MIT",
@@ -5570,7 +5615,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
       "dev": true,
       "license": "MIT",
@@ -5581,7 +5626,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express/-/express-5.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express/-/express-5.2.1.tgz",
       "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
       "dev": true,
       "license": "MIT",
@@ -5626,7 +5671,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
       "dev": true,
       "license": "MIT",
@@ -5649,7 +5694,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
       "dev": true,
       "license": "MIT",
@@ -5660,7 +5705,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha1-NtL2W8kJyHkAGN02+02T2myq4Gs=",
       "dev": true,
       "license": "MIT",
@@ -5682,7 +5727,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
       "dev": true,
       "license": "MIT",
@@ -5700,26 +5745,30 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha1-ardLjy0zIPIGSyqHo455Mf86VWE=",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
       "dev": true,
       "license": "MIT",
@@ -5733,7 +5782,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
       "dev": true,
       "license": "MIT",
@@ -5744,7 +5793,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
       "dev": true,
       "license": "MIT",
@@ -5761,19 +5810,41 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
+      "version": "1.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha1-FuAD0NtKwk/Z3xaO34cWJd7q498=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha1-2TicQ8Coz2o1XbRk0h4HCSpASTo=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
       "dev": true,
       "license": "MIT",
@@ -5790,7 +5861,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/send/-/send-1.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/send/-/send-1.2.1.tgz",
       "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
       "dev": true,
       "license": "MIT",
@@ -5818,7 +5889,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
       "dev": true,
       "license": "MIT",
@@ -5839,7 +5910,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
       "dev": true,
       "license": "MIT",
@@ -5850,7 +5921,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
       "dev": true,
       "license": "MIT",
@@ -5869,9 +5940,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+      "version": "2.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha1-2TicQ8Coz2o1XbRk0h4HCSpASTo=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5898,7 +5969,7 @@
     },
     "node_modules/@nodable/entities": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nodable/entities/-/entities-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@nodable/entities/-/entities-3.0.0.tgz",
       "integrity": "sha1-aUcDvIZNMOrtVcLj3vANvWFJNnA=",
       "dev": true,
       "funding": [
@@ -6361,7 +6432,7 @@
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha1-4Mm3te29sbUM4ywSfoXogIctVu4=",
       "dev": true,
       "license": "MIT",
@@ -6653,9 +6724,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6750,9 +6821,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
-      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
+      "version": "0.3.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+      "integrity": "sha1-MyhVu9cpqzbgd5st/CTtySDRJGE=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6956,9 +7027,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha1-ANHdlAshjf8uSTCdQQ2LshIVkiU=",
+      "version": "0.8.15",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha1-cev4Bynk6VIh1Rmsmx4erqd4SQc=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7041,7 +7112,7 @@
     },
     "node_modules/address": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/address/-/address-1.2.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/address/-/address-1.2.2.tgz",
       "integrity": "sha1-K1JI2sVIWmOQUyxqUX/aLj+qyJ4=",
       "dev": true,
       "license": "MIT",
@@ -7062,7 +7133,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "dev": true,
       "license": "MIT",
@@ -7197,7 +7268,7 @@
     },
     "node_modules/anynum": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/anynum/-/anynum-1.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/anynum/-/anynum-1.0.1.tgz",
       "integrity": "sha1-KqwA4I3603JsHUYuYNvC+DFlmkQ=",
       "dev": true,
       "funding": [
@@ -7211,7 +7282,7 @@
     },
     "node_modules/applicationinsights": {
       "version": "1.8.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/applicationinsights/-/applicationinsights-1.8.10.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/applicationinsights/-/applicationinsights-1.8.10.tgz",
       "integrity": "sha1-//pILNFRmID7iIU2qHCBrAUTBmc=",
       "dev": true,
       "license": "MIT",
@@ -7279,7 +7350,7 @@
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/array-timsort/-/array-timsort-1.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha1-PJ5BmeVPsrnD/ll2OWohYU7w2SY=",
       "dev": true,
       "license": "MIT",
@@ -7424,7 +7495,7 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true,
       "license": "MIT",
@@ -7451,7 +7522,7 @@
     },
     "node_modules/async-hook-jl": {
       "version": "1.7.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
       "integrity": "sha1-T9JcL4ZNuvJ5xhDXO/l7GyhZXmg=",
       "dev": true,
       "license": "MIT",
@@ -7465,7 +7536,7 @@
     },
     "node_modules/async-listener": {
       "version": "0.6.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async-listener/-/async-listener-0.6.10.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha1-p8l6vlcLpgLXgic8DeYKUePhfLw=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -7480,7 +7551,7 @@
     },
     "node_modules/async-listener/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "dev": true,
       "license": "ISC",
@@ -7508,7 +7579,7 @@
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=",
       "dev": true,
       "license": "ISC",
@@ -7548,22 +7619,22 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha1-1j+YY7zYk4gVyG+eKr04AYnZbf4=",
+      "version": "1.20.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha1-UVUTRFqmDnHQS2UhymIQgpzLR4Y=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
       "version": "3.9.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axios-retry/-/axios-retry-3.9.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha1-yJJKh4HI4KLFJEq/dz3rdWazgw0=",
       "dev": true,
       "license": "Apache-2.0",
@@ -7575,7 +7646,7 @@
     },
     "node_modules/axios/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
       "dev": true,
       "license": "MIT",
@@ -7589,7 +7660,7 @@
     },
     "node_modules/axios/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
       "dev": true,
       "license": "MIT",
@@ -7674,13 +7745,16 @@
       "peer": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.20",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {
@@ -7821,9 +7895,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.18",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7850,9 +7924,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -7870,11 +7944,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7911,7 +7985,7 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -8007,7 +8081,7 @@
     },
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
       "integrity": "sha1-A/lk8ZUiumQ7GwaTrLkVL+IHS6o=",
       "dev": true,
       "license": "MIT",
@@ -8046,9 +8120,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001810",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -8074,7 +8148,7 @@
     },
     "node_modules/chai": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-4.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/chai/-/chai-4.5.0.tgz",
       "integrity": "sha1-cH5Jkjr92bE6iwtH0z1zLROBL9g=",
       "dev": true,
       "license": "MIT",
@@ -8117,7 +8191,7 @@
     },
     "node_modules/charenc": {
       "version": "0.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -8128,7 +8202,7 @@
     },
     "node_modules/check-error": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/check-error/-/check-error-1.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha1-plAuQxKn7pafZG6Duz3dVigb1pQ=",
       "dev": true,
       "license": "MIT",
@@ -8158,7 +8232,7 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha1-mFXmTs0kCpzEJnzopKpdJKHaFeQ=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -8366,7 +8440,7 @@
     },
     "node_modules/cls-hooked": {
       "version": "4.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/cls-hooked/-/cls-hooked-4.2.2.tgz",
       "integrity": "sha1-rS6aQJJoDNr/6y01UdoOIl6uGQg=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -8382,7 +8456,7 @@
     },
     "node_modules/cls-hooked/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "dev": true,
       "license": "ISC",
@@ -8438,7 +8512,7 @@
     },
     "node_modules/comment-json": {
       "version": "4.6.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/comment-json/-/comment-json-4.6.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/comment-json/-/comment-json-4.6.2.tgz",
       "integrity": "sha1-I12KkI4hGFWwBoJIp5Sv3bh2cK8=",
       "dev": true,
       "license": "MIT",
@@ -8544,7 +8618,7 @@
     },
     "node_modules/continuation-local-storage": {
       "version": "3.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -8680,7 +8754,7 @@
     },
     "node_modules/crypt": {
       "version": "0.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -8691,7 +8765,7 @@
     },
     "node_modules/cryptr": {
       "version": "6.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cryptr/-/cryptr-6.4.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/cryptr/-/cryptr-6.4.0.tgz",
       "integrity": "sha1-pfSbd2edQRzutsvwrNUalPPQUKk=",
       "dev": true,
       "license": "MIT",
@@ -8727,7 +8801,7 @@
     },
     "node_modules/cssom": {
       "version": "0.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssom/-/cssom-0.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha1-0lT6ks2Lb72DgRufuu00ZjzBfDY=",
       "dev": true,
       "license": "MIT",
@@ -8896,16 +8970,15 @@
     },
     "node_modules/deep-diff": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deep-diff/-/deep-diff-1.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/deep-diff/-/deep-diff-1.0.2.tgz",
       "integrity": "sha1-r9PR90kRW+ll6Jxj7cersVBrnCY=",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deep-eql/-/deep-eql-4.1.4.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/deep-eql/-/deep-eql-4.1.4.tgz",
       "integrity": "sha1-0NORKGWRG7j6xa+046z6aijccrc=",
       "dev": true,
       "license": "MIT",
@@ -9049,7 +9122,7 @@
     },
     "node_modules/detect-port": {
       "version": "1.6.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-port/-/detect-port-1.6.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/detect-port/-/detect-port-1.6.1.tgz",
       "integrity": "sha1-ReQHOZfF8pK5V8tnj7C7jtQlCmc=",
       "dev": true,
       "license": "MIT",
@@ -9068,7 +9141,7 @@
     },
     "node_modules/diagnostic-channel": {
       "version": "0.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
       "integrity": "sha1-f6oUPhB/hhvjBGU560kI+qs/U/0=",
       "dev": true,
       "license": "MIT",
@@ -9079,7 +9152,7 @@
     },
     "node_modules/diagnostic-channel-publishers": {
       "version": "0.4.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
       "integrity": "sha1-V8O4C35/V2+VvjolfV6UVQ8AgtY=",
       "dev": true,
       "license": "MIT",
@@ -9090,7 +9163,7 @@
     },
     "node_modules/diagnostic-channel/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "dev": true,
       "license": "ISC",
@@ -9218,7 +9291,7 @@
     },
     "node_modules/dotenv": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dotenv/-/dotenv-8.6.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha1-Bhr2ZNGff02PxuT/m1hM4jety4s=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9259,7 +9332,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -9275,15 +9348,15 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.418",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
+      "integrity": "sha1-QMy/bVckR2YwQWEeBZJLU7yaAzE=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha1-VrFA6PaZI3Wz18ssqxzHQy2WMug=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9550,7 +9623,7 @@
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es6-promise/-/es6-promise-3.3.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true,
       "license": "MIT",
@@ -9909,9 +9982,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10132,7 +10205,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -10207,7 +10280,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha1-EVdiLi9Td7tq7yEUNycougwVaYk=",
       "dev": true,
       "license": "MIT",
@@ -10220,9 +10293,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha1-ThmOuRzTM9Co3cwDZQKzYYol9Ek=",
+      "version": "3.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha1-uWy7fazk83dPWKnjsa6aSlJIcuI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10243,8 +10316,8 @@
     },
     "node_modules/express": {
       "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express/-/express-4.22.2.tgz",
+      "integrity": "sha1-wXrgmB5e/CSyInLw4EHEZiUDtwA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10289,13 +10362,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha1-WSLb923yEkYRzqlV2TQys3UUsvM=",
+      "version": "8.7.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha1-h3OaNTXn2zyoe0p3sexcwsCnEeQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -10392,16 +10466,16 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha1-xAaoO25w2eNc47MKgRQd8wrrqIQ=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
+      "version": "3.1.6",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha1-v90wjvdj+DX+0Fnzxskl9wjjPjo=",
       "dev": true,
       "funding": [
         {
@@ -10416,9 +10490,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
-      "integrity": "sha1-vISYBHlv5Hv5FQIt2Tmw/DC6RV0=",
+      "version": "1.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha1-7wWzU7RVl0g9+wnUUKBiorrsOoI=",
       "dev": true,
       "funding": [
         {
@@ -10433,24 +10507,10 @@
         "xml-naming": "^0.3.0"
       }
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
-      "integrity": "sha1-GTE/fJOGxH+kod5SdUe3PtLPzt4=",
+      "version": "5.11.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha1-DuZy/M4XEMOBhbgpDXfpiAb/C/s=",
       "dev": true,
       "funding": [
         {
@@ -10465,7 +10525,7 @@
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",
-        "strnum": "^2.4.1",
+        "strnum": "^2.4.2",
         "xml-naming": "^0.3.0"
       },
       "bin": {
@@ -10707,8 +10767,8 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "dev": true,
       "funding": [
         {
@@ -10769,7 +10829,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "dev": true,
       "license": "MIT",
@@ -10826,7 +10886,7 @@
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-9.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
       "dev": true,
       "license": "MIT",
@@ -10899,7 +10959,7 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-func-name/-/get-func-name-2.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha1-DXzyDNE/2oCGaf+oj0/8ejlD/EE=",
       "dev": true,
       "license": "MIT",
@@ -11037,9 +11097,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11117,7 +11177,7 @@
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
       "dev": true,
       "license": "MIT",
@@ -11259,9 +11319,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha1-TVewUcZmF7ADt7oxiRDLW3nEx6w=",
+      "version": "4.13.5",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha1-PflGPEZooDIcOVFTCfWJHjiOlwk=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11271,7 +11331,7 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-escaper/-/html-escaper-3.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha1-TTNmdGUr6x3Lwp72trp/a+b9/tY=",
       "dev": true,
       "license": "MIT",
@@ -11436,7 +11496,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "dev": true,
       "license": "MIT",
@@ -11483,7 +11543,7 @@
     },
     "node_modules/http2-client": {
       "version": "1.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http2-client/-/http2-client-1.3.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha1-IMnckJ48yYKE3SCvJDLFJAht8YE=",
       "dev": true,
       "license": "MIT",
@@ -11491,7 +11551,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "dev": true,
       "license": "MIT",
@@ -11877,9 +11937,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
+      "version": "10.7.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha1-lxNCnxZ4ft6PZC9iVbQftRXIJdk=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11965,7 +12025,7 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true,
       "license": "MIT",
@@ -12269,7 +12329,7 @@
     },
     "node_modules/is-retry-allowed": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha1-iPNMvSNuBD5xtpMtCbDGX7e01x0=",
       "dev": true,
       "license": "MIT",
@@ -12375,9 +12435,9 @@
       }
     },
     "node_modules/is-unsafe": {
-      "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-unsafe/-/is-unsafe-2.0.0.tgz",
-      "integrity": "sha1-wNzk4GdCZi3eJjYBYOQU6kh9ouk=",
+      "version": "2.0.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha1-ux6tF/GqaI9kMyWLVh6YsaRaGvw=",
       "dev": true,
       "funding": [
         {
@@ -12546,9 +12606,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha1-CXUZetlzJRIhxlijzdxLlRolDC0=",
+      "version": "6.2.10",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha1-twQ2ySDEs/lzFMKKi4YSwVsdnn8=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12557,9 +12617,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.9.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-base64/-/js-base64-3.9.1.tgz",
-      "integrity": "sha1-AjNcFsajEckTXfpxtLO38a8z3Ug=",
+      "version": "3.9.3",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha1-d7NKogp2XRUL5of8NI1Z/n0CIYg=",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
@@ -12571,9 +12631,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {
@@ -12637,7 +12697,7 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha1-6Y7nsYmf9KGEU00fFnwojGa77/Q=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -12681,7 +12741,7 @@
     },
     "node_modules/jsonschema": {
       "version": "1.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonschema/-/jsonschema-1.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jsonschema/-/jsonschema-1.5.0.tgz",
       "integrity": "sha1-9qzrGrkSNWPdkB0F+B+dSIPTt9g=",
       "dev": true,
       "license": "MIT",
@@ -12692,7 +12752,7 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=",
       "dev": true,
       "license": "MIT",
@@ -12716,7 +12776,7 @@
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -12770,7 +12830,7 @@
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jwa/-/jwa-2.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
       "dev": true,
       "license": "MIT",
@@ -12783,7 +12843,7 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jws/-/jws-4.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jws/-/jws-4.0.1.tgz",
       "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
       "dev": true,
       "license": "MIT",
@@ -12826,7 +12886,7 @@
     },
     "node_modules/klaw": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/klaw/-/klaw-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha1-sRvsnPJJLwZ1bW6Amrc6KRAlkUY=",
       "dev": true,
       "license": "MIT",
@@ -12861,7 +12921,7 @@
     },
     "node_modules/linkedom": {
       "version": "0.18.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/linkedom/-/linkedom-0.18.13.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/linkedom/-/linkedom-0.18.13.tgz",
       "integrity": "sha1-20WC1C1WBpYd2OWW/Cc72MBvUN8=",
       "dev": true,
       "license": "ISC",
@@ -12887,7 +12947,7 @@
     },
     "node_modules/linkedom/node_modules/boolbase": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/boolbase/-/boolbase-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/boolbase/-/boolbase-2.0.0.tgz",
       "integrity": "sha1-gylo0hHVwAjYM7huBJuzlDA25bE=",
       "dev": true,
       "license": "ISC",
@@ -12902,7 +12962,7 @@
     },
     "node_modules/linkedom/node_modules/css-select": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-select/-/css-select-7.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/css-select/-/css-select-7.0.0.tgz",
       "integrity": "sha1-dTK6tZd7Hw6DvBYDZmHb4JaLTew=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -12924,7 +12984,7 @@
     },
     "node_modules/linkedom/node_modules/css-what": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-what/-/css-what-8.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/css-what/-/css-what-8.0.0.tgz",
       "integrity": "sha1-I3iJ1gxK/vRzaJLznhM6tMjCHww=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -12939,7 +12999,7 @@
     },
     "node_modules/linkedom/node_modules/dom-serializer": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/dom-serializer/-/dom-serializer-3.1.1.tgz",
       "integrity": "sha1-VL5w7k/MLaAQ9IgWXmIpR5jcV9M=",
       "dev": true,
       "license": "MIT",
@@ -12959,7 +13019,7 @@
     },
     "node_modules/linkedom/node_modules/dom-serializer/node_modules/domelementtype": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
       "integrity": "sha1-5sCiS9Ocpet+pnqY0vaZSX17zFU=",
       "dev": true,
       "funding": [
@@ -12976,7 +13036,7 @@
     },
     "node_modules/linkedom/node_modules/domhandler": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domhandler/-/domhandler-6.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domhandler/-/domhandler-6.0.1.tgz",
       "integrity": "sha1-dfNRoDpuEMNeCEGPnPDSh+AHl88=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -12994,7 +13054,7 @@
     },
     "node_modules/linkedom/node_modules/domhandler/node_modules/domelementtype": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
       "integrity": "sha1-5sCiS9Ocpet+pnqY0vaZSX17zFU=",
       "dev": true,
       "funding": [
@@ -13011,7 +13071,7 @@
     },
     "node_modules/linkedom/node_modules/domutils": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domutils/-/domutils-4.0.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domutils/-/domutils-4.0.2.tgz",
       "integrity": "sha1-DBrB/b6PVUpgpvXrFD7oVjAyfJQ=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13031,7 +13091,7 @@
     },
     "node_modules/linkedom/node_modules/domutils/node_modules/domelementtype": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domelementtype/-/domelementtype-3.0.0.tgz",
       "integrity": "sha1-5sCiS9Ocpet+pnqY0vaZSX17zFU=",
       "dev": true,
       "funding": [
@@ -13048,7 +13108,7 @@
     },
     "node_modules/linkedom/node_modules/entities": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-8.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/entities/-/entities-8.0.0.tgz",
       "integrity": "sha1-wd9f42AkKXR/ojPQ3SbxQvDOR0M=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13062,7 +13122,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2": {
       "version": "10.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/htmlparser2/-/htmlparser2-10.1.0.tgz",
       "integrity": "sha1-/j8uEsc7bkYtThA5XbnBEZ5NauQ=",
       "dev": true,
       "funding": [
@@ -13083,7 +13143,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2/node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=",
       "dev": true,
       "license": "MIT",
@@ -13099,7 +13159,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-4.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/entities/-/entities-4.5.0.tgz",
       "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13113,7 +13173,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13130,7 +13190,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2/node_modules/domutils": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domutils/-/domutils-3.2.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha1-7b/itmiwwdl8JLrw8QYrEyIhvHg=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13146,7 +13206,7 @@
     },
     "node_modules/linkedom/node_modules/htmlparser2/node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-7.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/entities/-/entities-7.0.1.tgz",
       "integrity": "sha1-JuioiInbY0F9y5oeeaPxvJK1l2s=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13160,7 +13220,7 @@
     },
     "node_modules/linkedom/node_modules/nth-check": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nth-check/-/nth-check-3.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/nth-check/-/nth-check-3.0.1.tgz",
       "integrity": "sha1-pe3pYGD38LdNfT2EJfKo8GEMV3Y=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -13235,7 +13295,7 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true,
       "license": "MIT",
@@ -13243,7 +13303,7 @@
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true,
       "license": "MIT",
@@ -13251,7 +13311,7 @@
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "dev": true,
       "license": "MIT",
@@ -13259,7 +13319,7 @@
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "dev": true,
       "license": "MIT",
@@ -13267,7 +13327,7 @@
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true,
       "license": "MIT",
@@ -13275,7 +13335,7 @@
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true,
       "license": "MIT",
@@ -13289,7 +13349,7 @@
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true,
       "license": "MIT",
@@ -13356,7 +13416,7 @@
     },
     "node_modules/loupe": {
       "version": "2.3.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loupe/-/loupe-2.3.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha1-bmm31Nt9OrQ2MoAT030cjDVAxpc=",
       "dev": true,
       "license": "MIT",
@@ -13401,7 +13461,7 @@
     },
     "node_modules/md5": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/md5/-/md5-2.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/md5/-/md5-2.3.0.tgz",
       "integrity": "sha1-w9qaaq46MLRreww0m4exENw72k8=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -13500,7 +13560,7 @@
     },
     "node_modules/mime": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime/-/mime-2.6.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mime/-/mime-2.6.0.tgz",
       "integrity": "sha1-oqaCqVzU0MsdYlfij4PafjWAA2c=",
       "dev": true,
       "license": "MIT",
@@ -13583,7 +13643,7 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha1-atdsOo8QInybUdHJrI4wsn9aJRw=",
       "dev": true,
       "license": "MIT",
@@ -13629,9 +13689,9 @@
       "peer": true
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
+      "version": "11.8.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha1-kWPMWWAOwmRw9rBA4wqlGsyXPtI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13666,9 +13726,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13757,7 +13817,7 @@
     },
     "node_modules/mustache": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mustache/-/mustache-4.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha1-5YkjJNYKEuycKnM1ntylKXK/b2Q=",
       "dev": true,
       "license": "MIT",
@@ -13928,7 +13988,7 @@
     },
     "node_modules/neverthrow": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/neverthrow/-/neverthrow-3.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/neverthrow/-/neverthrow-3.2.0.tgz",
       "integrity": "sha1-VOIoBycLlcqzuMXoDKhyzzPoTkI=",
       "dev": true,
       "license": "MIT",
@@ -14023,7 +14083,7 @@
     },
     "node_modules/node-fetch-h2": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
       "integrity": "sha1-xhiDJfm9PYNAIL8PLW3BfO0iQaw=",
       "dev": true,
       "license": "MIT",
@@ -14055,7 +14115,7 @@
     },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-readfiles/-/node-readfiles-0.2.0.tgz",
       "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
       "dev": true,
       "license": "MIT",
@@ -14065,11 +14125,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.54",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -14100,7 +14163,7 @@
     },
     "node_modules/oas-kit-common": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
       "integrity": "sha1-bYys9ukJeWekx+qLy8vXcBjh9TU=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -14111,7 +14174,7 @@
     },
     "node_modules/oas-linter": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oas-linter/-/oas-linter-3.2.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/oas-linter/-/oas-linter-3.2.2.tgz",
       "integrity": "sha1-q2ozc2MTSQZZA1ymgC3Es11Iqh4=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -14127,7 +14190,7 @@
     },
     "node_modules/oas-linter/node_modules/yaml": {
       "version": "1.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-1.10.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha1-duQH7ZXEJoT7jhRkHl3mL+ZbvLM=",
       "dev": true,
       "license": "ISC",
@@ -14138,7 +14201,7 @@
     },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/oas-resolver/-/oas-resolver-2.5.6.tgz",
       "integrity": "sha1-EEMFact9rKVhFckV5hHrxVFcVhs=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -14159,7 +14222,7 @@
     },
     "node_modules/oas-resolver/node_modules/yaml": {
       "version": "1.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-1.10.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha1-duQH7ZXEJoT7jhRkHl3mL+ZbvLM=",
       "dev": true,
       "license": "ISC",
@@ -14170,7 +14233,7 @@
     },
     "node_modules/oas-schema-walker": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
       "integrity": "sha1-dMPNR7cP+OCxmtraFEVbXTrDiiI=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -14181,7 +14244,7 @@
     },
     "node_modules/oas-validator": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oas-validator/-/oas-validator-5.0.8.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/oas-validator/-/oas-validator-5.0.8.tgz",
       "integrity": "sha1-OH6Q33yvotP/yDtfuXYFK4fnPCg=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -14202,7 +14265,7 @@
     },
     "node_modules/oas-validator/node_modules/yaml": {
       "version": "1.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-1.10.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha1-duQH7ZXEJoT7jhRkHl3mL+ZbvLM=",
       "dev": true,
       "license": "ISC",
@@ -14548,7 +14611,7 @@
     },
     "node_modules/office-addin-manifest-converter": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.1.tgz",
       "integrity": "sha1-2i1cqW+yVk7ARgAqqb3tE9RL43M=",
       "dev": true,
       "license": "MIT",
@@ -14564,7 +14627,7 @@
     },
     "node_modules/office-addin-manifest-converter/node_modules/commander": {
       "version": "9.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/commander/-/commander-9.5.0.tgz",
       "integrity": "sha1-vAjR61zt98y3l6lhmdQce8PmDTA=",
       "dev": true,
       "license": "MIT",
@@ -14736,7 +14799,7 @@
     },
     "node_modules/office-addin-project": {
       "version": "1.0.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/office-addin-project/-/office-addin-project-1.0.10.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-project/-/office-addin-project-1.0.10.tgz",
       "integrity": "sha1-bxoq659R1DLexjca078t7hbdJmQ=",
       "dev": true,
       "license": "MIT",
@@ -14756,7 +14819,7 @@
     },
     "node_modules/office-addin-project/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "license": "MIT",
@@ -14772,7 +14835,7 @@
     },
     "node_modules/office-addin-project/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "license": "MIT",
@@ -14783,7 +14846,7 @@
     },
     "node_modules/office-addin-project/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true,
       "license": "MIT",
@@ -14885,7 +14948,7 @@
     },
     "node_modules/openapi-types": {
       "version": "7.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/openapi-types/-/openapi-types-7.2.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/openapi-types/-/openapi-types-7.2.3.tgz",
       "integrity": "sha1-g4KZEaNBCgIvDgzysLLmcjLM+W4=",
       "dev": true,
       "license": "MIT",
@@ -14910,7 +14973,7 @@
     },
     "node_modules/original-fs": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/original-fs/-/original-fs-1.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/original-fs/-/original-fs-1.2.0.tgz",
       "integrity": "sha1-6mxRF+5x/mqfgJEw3gWQZ2Nwteg=",
       "dev": true,
       "license": "Unlicense",
@@ -15050,7 +15113,7 @@
     },
     "node_modules/path": {
       "version": "0.12.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path/-/path-0.12.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/path/-/path-0.12.7.tgz",
       "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
       "dev": true,
       "license": "MIT",
@@ -15071,7 +15134,7 @@
     },
     "node_modules/path-expression-matcher": {
       "version": "1.6.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
       "integrity": "sha1-VnxzwHGX6dzvJOkO3NxXEFZZkWg=",
       "dev": true,
       "funding": [
@@ -15132,7 +15195,7 @@
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathval/-/pathval-1.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
       "dev": true,
       "license": "MIT",
@@ -15168,7 +15231,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha1-O0RGhlsXsXRems4gFqMfSN32Iw0=",
       "dev": true,
       "license": "MIT",
@@ -15314,7 +15377,7 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha1-yLneKvay8WAQZ/mOAaxmuqIjFB8=",
       "dev": true,
       "license": "MIT",
@@ -15327,7 +15390,7 @@
     },
     "node_modules/proper-lockfile/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "dev": true,
       "license": "ISC",
@@ -15348,7 +15411,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha1-p0h1aK2tV3z6qn6IxJyrOrMIGro=",
       "dev": true,
       "license": "MIT",
@@ -15411,13 +15474,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -15610,7 +15674,7 @@
     },
     "node_modules/readline-sync": {
       "version": "1.4.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readline-sync/-/readline-sync-1.4.10.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/readline-sync/-/readline-sync-1.4.10.tgz",
       "integrity": "sha1-Qd9/u0tjEtZzARWUFFcFv1bYhzs=",
       "dev": true,
       "license": "MIT",
@@ -15633,7 +15697,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha1-JM9yH+YGdxRrt37rDh+d7OPWWFk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -15663,7 +15727,7 @@
     },
     "node_modules/reftools": {
       "version": "1.1.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reftools/-/reftools-1.1.9.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/reftools/-/reftools-1.1.9.tgz",
       "integrity": "sha1-4W4Z9mLM1GSGBTEsBtNOXaOit34=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -15947,7 +16011,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "license": "MIT",
@@ -16506,7 +16570,7 @@
     },
     "node_modules/shimmer": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shimmer/-/shimmer-1.2.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -16514,7 +16578,7 @@
     },
     "node_modules/should": {
       "version": "13.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should/-/should-13.2.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should/-/should-13.2.3.tgz",
       "integrity": "sha1-ltjlrPPpe0nYm1H+qlro0H71jxA=",
       "dev": true,
       "license": "MIT",
@@ -16529,7 +16593,7 @@
     },
     "node_modules/should-equal": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should-equal/-/should-equal-2.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha1-YHLPgwRzYIZ+aOmLCdcRQ9BO4MM=",
       "dev": true,
       "license": "MIT",
@@ -16540,7 +16604,7 @@
     },
     "node_modules/should-format": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should-format/-/should-format-3.0.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should-format/-/should-format-3.0.3.tgz",
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "dev": true,
       "license": "MIT",
@@ -16552,7 +16616,7 @@
     },
     "node_modules/should-type": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should-type/-/should-type-1.4.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should-type/-/should-type-1.4.0.tgz",
       "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
       "dev": true,
       "license": "MIT",
@@ -16560,7 +16624,7 @@
     },
     "node_modules/should-type-adaptors": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "integrity": "sha1-QB5/M7VTMDOUTVzYvytlAneS4no=",
       "dev": true,
       "license": "MIT",
@@ -16572,21 +16636,22 @@
     },
     "node_modules/should-util": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/should-util/-/should-util-1.0.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha1-+w1xM49TKjoUkhNjni0yy+qLyyg=",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -16598,13 +16663,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16786,7 +16852,7 @@
     },
     "node_modules/stack-chain": {
       "version": "1.3.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stack-chain/-/stack-chain-1.3.7.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
       "dev": true,
       "license": "MIT",
@@ -17080,9 +17146,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strnum/-/strnum-2.4.1.tgz",
-      "integrity": "sha1-hUF/aDETut6g/n4XInZ2+In/flg=",
+      "version": "2.4.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha1-r0OrUaBtBCJwI/wuQsoikhTsEPA=",
       "dev": true,
       "funding": [
         {
@@ -17122,7 +17188,7 @@
     },
     "node_modules/swagger2openapi": {
       "version": "7.0.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
       "integrity": "sha1-EsiNXed2yxy7p1iZSTD0CtCvrFk=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -17151,7 +17217,7 @@
     },
     "node_modules/swagger2openapi/node_modules/yaml": {
       "version": "1.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-1.10.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha1-duQH7ZXEJoT7jhRkHl3mL+ZbvLM=",
       "dev": true,
       "license": "ISC",
@@ -17191,9 +17257,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha1-s0Ba8utJNSPOQ3n1Menr2gYBvFk=",
+      "version": "7.5.22",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -17246,6 +17312,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tas-client": {
+      "version": "0.1.73",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tas-client/-/tas-client-0.1.73.tgz",
+      "integrity": "sha1-Laz2hUejeYnvFVTGUQ3BCKHqenE=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "axios": "^1.6.1"
       }
     },
     "node_modules/terser": {
@@ -17375,6 +17452,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -17570,7 +17658,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-detect/-/type-detect-4.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha1-3rJFPo8I3K566YxiaxPd2wFVkGw=",
       "dev": true,
       "license": "MIT",
@@ -17682,7 +17770,7 @@
     },
     "node_modules/typedi": {
       "version": "0.10.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typedi/-/typedi-0.10.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/typedi/-/typedi-0.10.0.tgz",
       "integrity": "sha1-6Pml7hALhK3b37V/6Q2NntKiHeo=",
       "dev": true,
       "license": "MIT",
@@ -17727,7 +17815,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -17742,7 +17830,7 @@
     },
     "node_modules/uhyphen": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uhyphen/-/uhyphen-0.2.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha1-j98GIzFEhuAgo8AO5cx6Ev5yK4E=",
       "dev": true,
       "license": "ISC",
@@ -17843,9 +17931,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {
@@ -17922,15 +18010,18 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha1-9tgdLhxl0Adi5eKbFsXS2ZXiCK0=",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -17941,7 +18032,7 @@
     },
     "node_modules/validator": {
       "version": "13.15.35",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/validator/-/validator-13.15.35.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/validator/-/validator-13.15.35.tgz",
       "integrity": "sha1-gc9FXFHxW2nY00C+WRTz+rANv38=",
       "dev": true,
       "license": "MIT",
@@ -17981,7 +18072,7 @@
     },
     "node_modules/vscode-jsonrpc": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
       "integrity": "sha1-p7907zJU0KDCcvqxXIISjjeLO+k=",
       "dev": true,
       "license": "MIT",
@@ -18878,7 +18969,7 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true,
       "license": "MIT",
@@ -19010,7 +19101,7 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
       "dev": true,
       "license": "MIT",
@@ -19027,7 +19118,7 @@
     },
     "node_modules/wsl-utils/node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "dev": true,
       "license": "MIT",
@@ -19044,7 +19135,7 @@
     },
     "node_modules/xml-naming": {
       "version": "0.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-naming/-/xml-naming-0.3.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/xml-naming/-/xml-naming-0.3.0.tgz",
       "integrity": "sha1-RsHhi/4oWEeZgt0qzPNNFudJ7aI=",
       "dev": true,
       "funding": [
@@ -19102,7 +19193,7 @@
     },
     "node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-5.0.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha1-AOLeRDY57Q14/YfeDSdGn7z/tTM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -19113,7 +19204,7 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "dev": true,
       "license": "ISC",
@@ -19255,9 +19346,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
+      "version": "4.5.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha1-4hXGJCDFKN15UeMftSxUOPH9GEo=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -19267,7 +19358,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha1-P6eZp7rdVUVBRy+2WEP9xGCy5ao=",
       "dev": true,
       "license": "ISC",


### PR DESCRIPTION
## Summary
Hardens the `convertToSingleHost.js` conversion script against command injection and updates dependencies to resolve `npm audit` vulnerabilities.

## Changes
- **convertToSingleHost.js**: Replace `childProcess.exec` (shell string) with `childProcess.execFile(process.execPath, ...)` when invoking `office-addin-manifest modify`. The manifest CLI is now resolved via `require.resolve("office-addin-manifest/cli.js")` and arguments are passed as an array with `shell: false`, so the project name and app ID are no longer interpolated into a shell command line.
- **package-lock.json**: Apply `npm audit fix` to pick up non-breaking security patches for transitive dependencies.
